### PR TITLE
Use disjoint types for contexts and sockets

### DIFF
--- a/src/simple-zmq.scm
+++ b/src/simple-zmq.scm
@@ -332,15 +332,19 @@
         zmq-msg-ptr)))
 
 (define (zmq-get-socket-option socket option)
-  (let ((opt (make-bytevector 8))
-	(size (make-bytevector 8)))
-    (bytevector-u8-set! size 0 8)
+  (let* ((value-size (if (= option ZMQ_TYPE)      ;TODO: Add more types.
+                         (sizeof int)
+                         (sizeof size_t)))
+         (opt        (make-bytevector value-size))
+	 (size       (make-bytevector (sizeof size_t))))
+    (bytevector-uint-set! size 0 value-size
+                          (native-endianness) (sizeof size_t))
     (let-values (((result errno) (zmq_getsockopt socket option
                                                  (bytevector->pointer opt)
                                                  (bytevector->pointer size))))
       (if (= result -1)
 	  (zmq-get-error errno)
-	  (bytevector-u8-ref opt 0)))))
+	  (bytevector-uint-ref opt 0 (native-endianness) value-size)))))
 
 (define (zmq-set-socket-option socket option value)
   (define (value->type+length value)

--- a/src/simple-zmq.scm
+++ b/src/simple-zmq.scm
@@ -3,7 +3,10 @@
   #:use-module (rnrs bytevectors)
   #:use-module (srfi srfi-11)
   #:use-module (ice-9 iconv)
-  #:export (zmq-get-buffer-size
+  #:export (zmq-context?
+            zmq-socket?
+
+            zmq-get-buffer-size
             zmq-set-buffer-size
             zmq-get-msg-encoding
             zmq-set-msg-encoding
@@ -158,6 +161,22 @@
 (define zmq_strerror   (import-func '*  "zmq_strerror"   (list int)    #f))
 (define zmq_unbind     (import-func int "zmq_unbind"     (list '* '*)  #t))
 
+;; Data types.
+
+(define-wrapped-pointer-type <zmq-context> zmq-context?
+  pointer->context context->pointer
+  (lambda (context port)
+    (format port "#<zmq-context ~a>"
+            (number->string (object-address context) 16))))
+
+(define-wrapped-pointer-type <zmq-socket> zmq-socket?
+  pointer->socket socket->pointer
+  (lambda (socket port)
+    (let ((type (zmq-get-socket-option socket ZMQ_TYPE)))
+      (format port "#<zmq-socket type: ~a ~a>"
+              type
+              (number->string (object-address socket) 16)))))
+
 ;; socket types
 (define ZMQ_PAIR   0)
 (define ZMQ_PUB    1)
@@ -291,36 +310,39 @@
   (let-values (((context errno) (zmq_ctx_new)))
     (if (null-pointer? context)
 	(zmq-get-error errno)
-	context)))
+	(pointer->context context))))
 
 (define (zmq-destroy-context context)
-  (let-values (((result errno) (zmq_ctx_term context)))
+  (let-values (((result errno) (zmq_ctx_term (context->pointer context))))
     (if (not (= result 0))
 	(zmq-get-error errno))))
 
 (define (zmq-create-socket context type)
-  (let-values (((socket errno) (zmq_socket context type)))
+  (let-values (((socket errno) (zmq_socket (context->pointer context) type)))
     (if (null-pointer? socket)
         (zmq-get-error errno)
-	socket)))
+	(pointer->socket socket))))
 
 (define (zmq-close-socket socket)
-  (let-values (((result errno) (zmq_close socket)))
+  (let-values (((result errno) (zmq_close (socket->pointer socket))))
     (if (not (= result 0))
 	(zmq-get-error errno))))
 
 (define (zmq-bind-socket socket address)
-  (let-values (((result errno) (zmq_bind socket (string->pointer address))))
+  (let-values (((result errno) (zmq_bind (socket->pointer socket)
+                                         (string->pointer address))))
     (if (not (= result 0))
 	(zmq-get-error errno))))
 
 (define (zmq-unbind-socket socket address)
-  (let-values (((result errno) (zmq_unbind socket (string->pointer address))))
+  (let-values (((result errno) (zmq_unbind (socket->pointer socket)
+                                           (string->pointer address))))
     (if (not (= result 0))
 	(zmq-get-error errno))))
 
 (define (zmq-connect socket address)
-  (let-values (((result errno) (zmq_connect socket (string->pointer address))))
+  (let-values (((result errno) (zmq_connect (socket->pointer socket)
+                                            (string->pointer address))))
     (if (not (= result 0))
 	(zmq-get-error errno))))
 
@@ -339,7 +361,8 @@
 	 (size       (make-bytevector (sizeof size_t))))
     (bytevector-uint-set! size 0 value-size
                           (native-endianness) (sizeof size_t))
-    (let-values (((result errno) (zmq_getsockopt socket option
+    (let-values (((result errno) (zmq_getsockopt (socket->pointer socket)
+                                                 option
                                                  (bytevector->pointer opt)
                                                  (bytevector->pointer size))))
       (if (= result -1)
@@ -362,19 +385,22 @@
       (zmq-get-error-msg "Wrong VALUE type in zmq-set-socket-option"))))
 
   (let*-values (((val len) (value->type+length value))
-                ((result errno) (zmq_setsockopt socket option
-                                                val len)))
+                ((result errno) (zmq_setsockopt (socket->pointer socket)
+                                                option val len)))
     (when (= result -1)
       (zmq-get-error errno))))
 
 (define (zmq-message-send socket message)
-  (let-values (((result errno) (zmq_msg_send message socket 0)))
+  (let-values (((result errno)
+                (zmq_msg_send message (socket->pointer socket) 0)))
     (if (= result -1)
 	(zmq-get-error errno))))
 
 (define (zmq-receive-bytevector socket len)
   (let  ((buffer (make-bytevector len 0)))
-    (let-values (((result errno) (zmq_recv socket (bytevector->pointer buffer) len 0)))
+    (let-values (((result errno) (zmq_recv (socket->pointer socket)
+                                           (bytevector->pointer buffer)
+                                           len 0)))
       (cond
        ((and (< result 0) (= errno 4)) (zmq-receive-bytevector socket len)) ;; apparently after getting EINTR error, socket should be read again
        ((< result 0) (zmq-get-error errno))
@@ -393,7 +419,7 @@
 
 (define* (zmq-send-bytevector socket data #:optional (flag 0))
   (let*  ((len (bytevector-length data)))
-    (let-values (((result errno) (zmq_send socket
+    (let-values (((result errno) (zmq_send (socket->pointer socket)
                                            (bytevector->pointer data)
                                            len flag)))
       (if (< result 0)
@@ -404,7 +430,8 @@
     (zmq-send-bytevector socket buffer flag)))
 
 (define (zmq-message-receive socket message)
-  (let-values (((result errno) (zmq_msg_recv message socket 0)))
+  (let-values (((result errno) (zmq_msg_recv message
+                                             (socket->pointer socket) 0)))
     (if (= result -1)
 	(zmq-get-error errno)
         message)))


### PR DESCRIPTION
Hello!

This patch adds disjoint types for contexts and sockets instead of exposing raw pointers to the user.

WDYT?

Thanks,
Ludo'.

PS: Sorry about the previous attempt, I had forgotten to rebase on `master`.