### PR TITLE
Add bindings for 'zmq_poll'.

### DIFF
--- a/src/simple-zmq.scm
+++ b/src/simple-zmq.scm
@@ -223,7 +223,7 @@
                     #:optional
                     (events (logior ZMQ_POLLIN ZMQ_POLLOUT ZMQ_POLLERR))
                     #:key (fd -1))
-  "Return a new \"poll item\" record suitable suitable for 'zmq-poll'.  The
+  "Return a new \"poll item\" record suitable for 'zmq-poll'.  The
 poll item will allow 'zmq-poll' to wait for EVENTS on SOCKET or on FD if
 SOCKET is #f.  EVENTS must be a bitwise-or of the ZMQ_POLL* constants."
   (%poll-item socket fd events))
@@ -595,7 +595,7 @@ omitted."
                  (cons (poll-item (if (null-pointer? socket)
                                       #f
                                       (pointer->socket socket))
-                                  events
+                                  revents
                                   #:fd fd)
                        result)))))))
 


### PR DESCRIPTION
Hi again!

This adds bindings for `zmq_poll`.  This allows you to wait for read/write/error events from several sockets with code like:

```scheme
(zmq-poll (list (poll-item shell-socket) (poll-item iopub-socket)))
```

Ludo'.

PS: GitHub's "merge" button apparently creates gratuitous merge commits so  I'd recommend merging using the `git` command-line tool if possible.  :-)