### PR TITLE
added support for the ZMQ_LAST_ENDPOINT option in zmq-get-socket-option

### DIFF
--- a/simple-zmq.scm.in
+++ b/simple-zmq.scm.in
@@ -480,9 +480,10 @@ ASCII etc."
         (pointer->message! msg-pointer))))
 
 (define (zmq-get-socket-option socket option)
-  (let* ((value-size (if (= option ZMQ_TYPE)      ;TODO: Add more types.
-                         (sizeof int)
-                         (sizeof size_t)))
+  (let* ((value-size (cond
+                      ((eq? ZMQ_TYPE option) (sizeof int))
+                      ((eq? ZMQ_LAST_ENDPOINT option) 30)
+                      (else (sizeof size_t))))
          (opt        (make-bytevector value-size))
          (size       (make-bytevector (sizeof size_t))))
     (bytevector-uint-set! size 0 value-size
@@ -493,7 +494,13 @@ ASCII etc."
                                                  (bytevector->pointer size))))
       (if (= result -1)
           (zmq-get-error errno)
-          (bytevector-uint-ref opt 0 (native-endianness) value-size)))))
+          (let ((len (bytevector-uint-ref size 0 (native-endianness) (sizeof size_t))))
+            (cond
+             ((eq? ZMQ_LAST_ENDPOINT option)
+              (let ((new-bv (make-bytevector (1- len))))
+                (bytevector-copy! opt 0 new-bv 0 (1- len))
+                (bytevector->string new-bv "utf-8")))
+             (else (bytevector-uint-ref opt 0 (native-endianness) len))))))))
 
 (define (zmq-set-socket-option socket option value)
   (define (value->type+length value)


### PR DESCRIPTION
currently, running `(zmq-get-socket-option sock ZMQ_LAST_ENDPOINT)` throws an error due to the default size `(sizeof size_t)` this commit detects the `ZMQ_LAST_ENDPOINT` option, sets an appropriate buffer size and converts the opt bytevector back to a string.