### PR TITLE
'zmq-get-socket-option' recognizes ZMQ_EVENTS.

### DIFF
--- a/simple-zmq.scm.in
+++ b/simple-zmq.scm.in
@@ -1,7 +1,7 @@
 ;;; Guile-Simple-ZMQ --- ZeroMQ bindings for GNU Guile.
 ;;; Copyright © 2018 Evgeny Panfilov <epanfilov@gmail.com>
 ;;; Copyright © 2018 Pierre-Antoine Rouby <contact@parouby.fr>
-;;; Copyright © 2018, 2019 Ludovic Courtès <ludo@gnu.org>
+;;; Copyright © 2018, 2019, 2023 Ludovic Courtès <ludo@gnu.org>
 ;;; Copyright © 2020, 2021 Mathieu Othacehe <othacehe@gnu.org>
 ;;;
 ;;; This file is part of Guile-Simple-ZMQ.
@@ -513,6 +513,7 @@ ASCII etc."
                           ZMQ_BINDTODEVICE)))
          (int-result?
           (member option (list
+                          ZMQ_EVENTS
                           ZMQ_TYPE
                           ZMQ_SNDBUF
                           ZMQ_RCVBUF


### PR DESCRIPTION
Hi! This is to allow `(zmq-get-socket-options sock ZMQ_EVENTS)`.

Feedback welcome!